### PR TITLE
Add filter to disable update query tables

### DIFF
--- a/lib/QueryFilters.php
+++ b/lib/QueryFilters.php
@@ -38,8 +38,9 @@ class QueryFilters
     public function updateQueryTables(string $query) : string
     {
         $table = $this->determineTable($query);
+        $updateQueryTable = apply_filters('ctp_tables:update_query_table', true);
 
-        if ($table && in_array($table, $this->config['post_types'])) {
+        if ($table && $updateQueryTable && in_array($table, $this->config['post_types'])) {
             $table = str_replace('-', '_', $table);
 
             $query = str_replace($this->config['default_post_table'], $table, $query);


### PR DESCRIPTION
Hello,

I really like this plugin and I like your work to make it work again!

However, I find it usefull to be able to disable the plugin for specific requests
So I added a filter to be able to do it

To use it to disable the replacements in the requests, you can use :
```
add_filter('ctp_tables:update_query_table', '__return_false');
```

What do you think about it ?